### PR TITLE
feat: add rate limiting support for forest and tree

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -7,4 +7,6 @@ import (
 var (
 	// ErrNotExistsTree tree not exists
 	ErrNotExistsTree = errors.New("tree not exists")
+	// ErrRateLimited rate limited
+	ErrRateLimited = errors.New("rate limited")
 )

--- a/export.go
+++ b/export.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/tr1v3r/rule/driver"
 )
 
@@ -25,6 +27,9 @@ type Forest interface {
 	GetVal(treeName, path string) (rule []byte, err error)
 
 	Info() string
+
+	// SetRateLimit sets a global rate limit for all GetVal calls as a fallback.
+	SetRateLimit(r rate.Limit, burst int)
 }
 
 // Tree rule tree
@@ -50,6 +55,9 @@ type Tree interface {
 
 	// ShowStruct return tree info
 	ShowStruct() []byte
+
+	// SetRateLimit sets a rate limit for Get calls on this tree.
+	SetRateLimit(r rate.Limit, burst int)
 }
 
 // Rule rule for tree

--- a/forest.go
+++ b/forest.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tr1v3r/pkg/guard"
 	"github.com/tr1v3r/pkg/log"
+	"golang.org/x/time/rate"
 )
 
 var _ Forest = (*forest)(nil)
@@ -22,6 +23,9 @@ type forest struct {
 	bMu      sync.RWMutex
 	builders []TreeBuilder
 	builderM map[string]TreeBuilder
+
+	rlMu        sync.RWMutex
+	rateLimiter *rate.Limiter
 }
 
 // Register register tree builder
@@ -99,7 +103,27 @@ func (f *forest) GetVal(treeName, path string) (rule []byte, err error) {
 	if tree == nil {
 		return nil, ErrNotExistsTree
 	}
+
+	if !f.allowGet() {
+		return nil, ErrRateLimited
+	}
+
 	return tree.Get(path)
+}
+
+// allowGet checks if the rate limiter allows this request.
+func (f *forest) allowGet() bool {
+	f.rlMu.RLock()
+	limiter := f.rateLimiter
+	f.rlMu.RUnlock()
+	return limiter == nil || limiter.Allow()
+}
+
+// SetRateLimit sets a global rate limit for all GetVal calls.
+func (f *forest) SetRateLimit(r rate.Limit, burst int) {
+	f.rlMu.Lock()
+	defer f.rlMu.Unlock()
+	f.rateLimiter = rate.NewLimiter(r, burst)
 }
 
 // Info ...

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/tidwall/sjson v1.2.5
 	github.com/tr1v3r/pkg v0.1.8
 	github.com/tr1v3r/stream v0.0.1
+	golang.org/x/time v0.3.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -48,7 +49,6 @@ require (
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.7.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/tree.go
+++ b/tree.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/time/rate"
+
 	"github.com/tr1v3r/rule/driver"
 )
 
@@ -48,6 +50,9 @@ type tree struct {
 
 	procMu   sync.RWMutex
 	realized bool
+
+	rlMu        sync.RWMutex
+	rateLimiter *rate.Limiter
 }
 
 func (t *tree) lazy() *tree {
@@ -72,6 +77,21 @@ func (t *tree) build(rules ...Rule) error {
 func (t *tree) Name() string { return t.name }
 func (t *tree) Path() string { return t.path }
 
+// allowGet checks if the rate limiter allows this request.
+func (t *tree) allowGet() bool {
+	t.rlMu.RLock()
+	limiter := t.rateLimiter
+	t.rlMu.RUnlock()
+	return limiter == nil || limiter.Allow()
+}
+
+// SetRateLimit sets a rate limit for Get calls on this tree.
+func (t *tree) SetRateLimit(r rate.Limit, burst int) {
+	t.rlMu.Lock()
+	defer t.rlMu.Unlock()
+	t.rateLimiter = rate.NewLimiter(r, burst)
+}
+
 func (t *tree) Set(r Rule) error {
 	if level := t.driver.GetLevel(r.Path()); t.level == level { // check if level matched, include root node
 		return t.apply(r.Processors()...)
@@ -82,6 +102,10 @@ func (t *tree) Set(r Rule) error {
 func (t *tree) Get(path string) ([]byte, error) {
 	if t == nil {
 		return nil, ErrNotExistsTree
+	}
+
+	if !t.allowGet() {
+		return nil, ErrRateLimited
 	}
 
 	if err := t.realize(t.procs); err != nil {


### PR DESCRIPTION
## Summary
- Add rate limiting to `Forest` and `Tree` using `golang.org/x/time/rate`
- `SetRateLimit(r, burst)` configures a token-bucket limiter on both `Forest` (global fallback) and individual `Tree` instances
- `GetVal`/`Get` return `ErrRateLimited` when the limiter rejects a request
- Thread-safe with read/write mutex protecting the limiter pointer

## Test plan
- [ ] Verify existing tests pass (`go test ./...`)
- [ ] Test rate limiting on forest-level `GetVal` calls
- [ ] Test rate limiting on tree-level `Get` calls
- [ ] Verify no rate limiting when `SetRateLimit` is not called (nil limiter path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)