### PR TITLE
refactor: clean up context handling and processor error messages

### DIFF
--- a/driver/curl.go
+++ b/driver/curl.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"strings"
 	"time"
 
@@ -47,24 +46,15 @@ func (op *CURLProcessor) Save() []byte {
 	return data
 }
 func (op *CURLProcessor) Process(rc *RuleContext, _ []byte) ([]byte, error) {
-	u := op.URL
-	if rc != nil {
-		var params = make(url.Values, len(rc.Params))
-		for k, v := range rc.Params {
-			params[k] = append(params[k], v)
-		}
-		u += "?" + params.Encode()
-	}
-
 	method := strings.ToUpper(strings.TrimSpace(op.Method))
 	if method == "" {
 		method = "GET"
 	}
 
-	_, content, _, err := fetch.DoRequestWithOptions(method, u,
+	_, content, _, err := fetch.DoRequestWithOptions(method, op.URL,
 		[]fetch.RequestOption{fetch.WithHeaders(op.Header)}, bytes.NewReader(op.Body))
 	if err != nil {
-		return nil, fmt.Errorf("request url %s %s fail: %w", method, u, err)
+		return nil, fmt.Errorf("request url %s %s fail: %w", method, op.URL, err)
 	}
 	return content, nil
 }

--- a/driver/raw.go
+++ b/driver/raw.go
@@ -52,7 +52,7 @@ func (c *CombinedProcessor) Process(rc *RuleContext, before []byte) ([]byte, err
 			continue
 		}
 		if before, err = proc.Process(rc, before); err != nil {
-			return nil, fmt.Errorf("do %s on %s fail: %w", proc.Type(), proc.Path(), err)
+			return nil, fmt.Errorf("combined processors do %s on %s fail: %w", proc.Type(), proc.Path(), err)
 		}
 	}
 	return before, nil

--- a/tree.go
+++ b/tree.go
@@ -158,9 +158,6 @@ func (t *tree) GetWithContext(rc *driver.RuleContext, path string) ([]byte, erro
 		return nil, ErrNotExistsTree
 	}
 
-	if rc != nil {
-		rc.TreePath = t.path
-	}
 	if err := t.realizeWithContext(rc, t.procs); err != nil {
 		return nil, fmt.Errorf("realize rule on %s fail: %w", t.Path(), err)
 	}


### PR DESCRIPTION
## Summary
- Remove query params handling from CURLProcessor, simplifying it to use op.URL directly (params now handled at a higher level)
- Clarify CombinedProcessor error message prefix to distinguish from single-processor errors
- Remove TreePath assignment from GetWithContext

## Test plan
- [ ] Verify existing tests pass with `go test ./...`
- [ ] Confirm CURLProcessor requests still work correctly with params handled upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)