### PR TITLE
fix: improve CURL processor error diagnostics

### DIFF
--- a/driver/curl.go
+++ b/driver/curl.go
@@ -3,14 +3,70 @@ package driver
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/tr1v3r/pkg/fetch"
 )
 
 var _ Processor = (*CURLProcessor)(nil)
+
+const (
+	maxCURLHeaderDetailBytes = 4 * 1024
+	maxCURLBodyDetailBytes   = 4 * 1024
+	redactedValue            = "[REDACTED]"
+)
+
+// CURLProcessError contains the request and response details needed to diagnose
+// a failed CURLProcessor request. Sensitive header and URL values are redacted
+// from Error(), while the structured fields retain the original values for
+// callers that explicitly inspect the error.
+type CURLProcessError struct {
+	Method          string
+	URL             string
+	RequestHeader   http.Header
+	RequestBodySize int
+	StatusCode      int
+	ResponseHeader  http.Header
+	ResponseBody    []byte
+	Duration        time.Duration
+	Err             error
+}
+
+func (e *CURLProcessError) Error() string {
+	var details = []string{
+		fmt.Sprintf("method=%s", e.Method),
+		fmt.Sprintf("url=%s", strconv.Quote(redactURL(e.URL))),
+		fmt.Sprintf("request_headers=%s", formatCURLHeaders(e.RequestHeader)),
+		fmt.Sprintf("request_body_bytes=%d", e.RequestBodySize),
+		fmt.Sprintf("duration=%s", e.Duration),
+	}
+	if e.StatusCode != 0 {
+		status := fmt.Sprintf("%d", e.StatusCode)
+		if text := http.StatusText(e.StatusCode); text != "" {
+			status += " " + text
+		}
+		details = append(details,
+			fmt.Sprintf("status=%s", strconv.Quote(status)),
+			fmt.Sprintf("response_headers=%s", formatCURLHeaders(e.ResponseHeader)),
+			fmt.Sprintf("response_body=%s", formatCURLBody(e.ResponseBody)),
+		)
+	}
+	if e.Err != nil {
+		details = append(details, fmt.Sprintf("cause=%s", strconv.Quote(formatCURLCause(e.Err, e.URL))))
+	}
+	return "curl request failed: " + strings.Join(details, " ")
+}
+
+// Unwrap exposes transport, request-construction, and response-body read
+// failures to errors.Is/errors.As.
+func (e *CURLProcessError) Unwrap() error { return e.Err }
 
 // CURLProcessor
 type CURLProcessor struct {
@@ -51,10 +107,116 @@ func (op *CURLProcessor) Process(rc *RealizeContext, _ []byte) ([]byte, error) {
 		method = "GET"
 	}
 
-	_, content, _, err := fetch.DoRequestWithOptions(method, op.URL,
+	startedAt := time.Now()
+	statusCode, content, responseHeader, err := fetch.DoRequestWithOptions(method, op.URL,
 		[]fetch.RequestOption{fetch.WithHeaders(op.Header)}, bytes.NewReader(op.Body))
+	duration := time.Since(startedAt)
 	if err != nil {
-		return nil, fmt.Errorf("request url %s %s fail: %w", method, op.URL, err)
+		return nil, &CURLProcessError{
+			Method:          method,
+			URL:             op.URL,
+			RequestHeader:   cloneHTTPHeader(op.Header),
+			RequestBodySize: len(op.Body),
+			Duration:        duration,
+			Err:             err,
+		}
+	}
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return nil, &CURLProcessError{
+			Method:          method,
+			URL:             op.URL,
+			RequestHeader:   cloneHTTPHeader(op.Header),
+			RequestBodySize: len(op.Body),
+			StatusCode:      statusCode,
+			ResponseHeader:  responseHeader.Clone(),
+			ResponseBody:    bytes.Clone(content),
+			Duration:        duration,
+		}
 	}
 	return content, nil
+}
+
+func cloneHTTPHeader(header map[string][]string) http.Header {
+	if header == nil {
+		return nil
+	}
+	return http.Header(header).Clone()
+}
+
+func formatCURLHeaders(header http.Header) string {
+	if len(header) == 0 {
+		return "{}"
+	}
+	safe := header.Clone()
+	for name := range safe {
+		if isSensitiveHTTPName(name) {
+			safe[name] = []string{redactedValue}
+		}
+	}
+	data, err := json.Marshal(safe)
+	if err != nil {
+		return strconv.Quote(fmt.Sprintf("<unavailable: %v>", err))
+	}
+	return truncateCURLDetail(string(data), maxCURLHeaderDetailBytes)
+}
+
+func formatCURLBody(body []byte) string {
+	if len(body) == 0 {
+		return strconv.Quote("")
+	}
+	if !utf8.Valid(body) {
+		return strconv.Quote(fmt.Sprintf("<%d bytes of non-UTF-8 response data>", len(body)))
+	}
+	return strconv.Quote(truncateCURLDetail(string(body), maxCURLBodyDetailBytes))
+}
+
+func formatCURLCause(err error, rawURL string) string {
+	formatted := err.Error()
+	var urlError *url.Error
+	if errors.As(err, &urlError) {
+		formatted = strings.ReplaceAll(formatted, urlError.URL, redactURL(urlError.URL))
+	}
+	return strings.ReplaceAll(formatted, rawURL, redactURL(rawURL))
+}
+
+func truncateCURLDetail(detail string, limit int) string {
+	if len(detail) <= limit {
+		return detail
+	}
+	return detail[:limit] + fmt.Sprintf("... <truncated; total_bytes=%d>", len(detail))
+}
+
+func redactURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	if parsed.User != nil {
+		if _, hasPassword := parsed.User.Password(); hasPassword {
+			parsed.User = url.UserPassword(parsed.User.Username(), redactedValue)
+		}
+	}
+	query := parsed.Query()
+	for name := range query {
+		if isSensitiveHTTPName(name) {
+			query[name] = []string{redactedValue}
+		}
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+func isSensitiveHTTPName(name string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(name, "_", "-"))
+	switch normalized {
+	case "authorization", "proxy-authorization", "cookie", "set-cookie":
+		return true
+	}
+	return strings.Contains(normalized, "token") ||
+		strings.Contains(normalized, "secret") ||
+		strings.Contains(normalized, "password") ||
+		strings.Contains(normalized, "api-key") ||
+		strings.Contains(normalized, "apikey") ||
+		strings.Contains(normalized, "signature") ||
+		strings.Contains(normalized, "credential")
 }

--- a/driver/curl_test.go
+++ b/driver/curl_test.go
@@ -1,0 +1,175 @@
+package driver_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tr1v3r/ivy/driver"
+	"github.com/tr1v3r/pkg/fetch"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func useHTTPClient(t *testing.T, transport roundTripperFunc) {
+	t.Helper()
+	previous := fetch.DefaultClient()
+	fetch.SetDefaultClient(&http.Client{Transport: transport})
+	t.Cleanup(func() {
+		fetch.SetDefaultClient(previous)
+	})
+}
+
+func TestCURLProcessorReportsHTTPFailureDetails(t *testing.T) {
+	const (
+		responseBody = `{"error":"invalid payload","field":"name"}`
+		secretToken  = "secret-bearer-token"
+		sessionID    = "secret-session-id"
+	)
+	useHTTPClient(t, func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Header: http.Header{
+				"Content-Type": {"application/json"},
+				"Set-Cookie":   {"session=" + sessionID},
+				"X-Request-Id": {"req-123"},
+			},
+			Body:    io.NopCloser(strings.NewReader(responseBody)),
+			Request: request,
+		}, nil
+	})
+
+	op := &driver.CURLProcessor{
+		Method: "post",
+		URL:    "https://example.test/users?access_token=query-secret&view=summary",
+		Body:   []byte(`{"name":""}`),
+		Header: map[string][]string{
+			"Authorization": {"Bearer " + secretToken},
+			"Content-Type":  {"application/json"},
+		},
+	}
+	content, err := op.Process(nil, nil)
+	if err == nil {
+		t.Fatal("Process() error = nil, want an HTTP status error")
+	}
+	if content != nil {
+		t.Fatalf("Process() content = %q, want nil", content)
+	}
+
+	var processErr *driver.CURLProcessError
+	if !errors.As(err, &processErr) {
+		t.Fatalf("Process() error type = %T, want *driver.CURLProcessError", err)
+	}
+	if processErr.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("StatusCode = %d, want %d", processErr.StatusCode, http.StatusUnprocessableEntity)
+	}
+	if got := string(processErr.ResponseBody); got != responseBody {
+		t.Errorf("ResponseBody = %q, want %q", got, responseBody)
+	}
+	if got := processErr.ResponseHeader.Get("X-Request-ID"); got != "req-123" {
+		t.Errorf("X-Request-ID = %q, want %q", got, "req-123")
+	}
+
+	message := err.Error()
+	for _, want := range []string{
+		"method=POST",
+		"view=summary",
+		"access_token=%5BREDACTED%5D",
+		`"Authorization":["[REDACTED]"]`,
+		"request_body_bytes=11",
+		`status="422 Unprocessable Entity"`,
+		`"X-Request-Id":["req-123"]`,
+		`response_body="{\"error\":\"invalid payload\",\"field\":\"name\"}"`,
+	} {
+		if !strings.Contains(message, want) {
+			t.Errorf("error message does not contain %q:\n%s", want, message)
+		}
+	}
+	for _, secret := range []string{secretToken, sessionID, "query-secret"} {
+		if strings.Contains(message, secret) {
+			t.Errorf("error message leaked %q:\n%s", secret, message)
+		}
+	}
+}
+
+func TestCURLProcessorReportsRequestConstructionFailure(t *testing.T) {
+	op := &driver.CURLProcessor{
+		Method: " get ",
+		URL:    "://invalid-url",
+		Body:   []byte("request body"),
+	}
+	content, err := op.Process(nil, nil)
+	if err == nil {
+		t.Fatal("Process() error = nil, want a request construction error")
+	}
+	if content != nil {
+		t.Fatalf("Process() content = %q, want nil", content)
+	}
+
+	var processErr *driver.CURLProcessError
+	if !errors.As(err, &processErr) {
+		t.Fatalf("Process() error type = %T, want *driver.CURLProcessError", err)
+	}
+	if processErr.Err == nil {
+		t.Fatal("CURLProcessError.Err = nil, want underlying error")
+	}
+	if processErr.StatusCode != 0 {
+		t.Errorf("StatusCode = %d, want 0", processErr.StatusCode)
+	}
+	for _, want := range []string{
+		"method=GET",
+		`url="://invalid-url"`,
+		"request_body_bytes=12",
+		`cause="build new request fail:`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message does not contain %q:\n%s", want, err)
+		}
+	}
+}
+
+func TestCURLProcessorRedactsURLInTransportFailure(t *testing.T) {
+	useHTTPClient(t, func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("connection refused")
+	})
+
+	const secret = "query-secret"
+	op := &driver.CURLProcessor{
+		URL: "https://example.test/users?access_token=" + secret,
+	}
+	_, err := op.Process(nil, nil)
+	if err == nil {
+		t.Fatal("Process() error = nil, want a transport error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error message leaked URL secret:\n%s", err)
+	}
+	if !strings.Contains(err.Error(), "access_token=%5BREDACTED%5D") {
+		t.Fatalf("error message does not contain redacted URL:\n%s", err)
+	}
+}
+
+func TestCURLProcessorKeepsSuccessfulResponse(t *testing.T) {
+	useHTTPClient(t, func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Request:    request,
+		}, nil
+	})
+
+	content, err := (&driver.CURLProcessor{URL: "https://example.test"}).Process(nil, nil)
+	if err != nil {
+		t.Fatalf("Process() error = %v, want nil", err)
+	}
+	if got := string(content); got != "ok" {
+		t.Errorf("Process() content = %q, want %q", got, "ok")
+	}
+}


### PR DESCRIPTION
## Summary

- return a structured `CURLProcessError` with request, response, timing, and underlying failure details
- treat non-2xx HTTP responses as processor errors while redacting sensitive headers and URL parameters
- add focused tests for HTTP failures, request construction failures, transport failures, redaction, and successful responses

## Validation

- [x] `go test ./driver -run '^TestCURLProcessor' -count=1`
- [x] `go vet ./driver`
- [x] `go test ./... -run '^$'`

The repository's full local suite still includes pre-existing environment-dependent tests that require `https://xxx/ping` DNS access and `/tmp/rule.yml`.
